### PR TITLE
don't log errors to debug

### DIFF
--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/CheckForSeed.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/CheckForSeed.java
@@ -57,7 +57,7 @@ public class CheckForSeed extends AbstractProfileAction {
 					.getSubcontext(UsernamePasswordContext.class);
 			return true;
 		} catch (Exception e) {
-			log.debug("Error with doPreExecute", e);
+			log.error("Error with doPreExecute", e);
 			return false;
 
 		}

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/ExtractTokenFromForm.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/ExtractTokenFromForm.java
@@ -88,7 +88,7 @@ public class ExtractTokenFromForm extends AbstractExtractionAction {
 			}
 
 		} catch (Exception e) {
-			log.warn("{} Login by {} produced exception", getLogPrefix(),  e);
+			log.error("{} Login by {} produced exception", getLogPrefix(),  e);
 		}
 	}
 

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/GenerateNewToken.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/GenerateNewToken.java
@@ -64,7 +64,7 @@ public class GenerateNewToken extends AbstractProfileAction {
 					.getSubcontext(UsernamePasswordContext.class);
 			return true;
 		} catch (Exception e) {
-			log.debug("Error with doPreExecute", e);
+			log.error("Error with doPreExecute", e);
 			return false;
 
 		}
@@ -79,7 +79,7 @@ public class GenerateNewToken extends AbstractProfileAction {
 			log.debug("Trying to create new token for {}", upCtx.getUsername());
 			generateToken();
 		} catch (Exception e) {
-			log.debug("Failed to create new token", e);
+			log.error("Failed to create new token", e);
 		}
 
 	}
@@ -99,7 +99,7 @@ public class GenerateNewToken extends AbstractProfileAction {
 			tokenCtx.setSharedSecret(sharedSecret);
 
 		} catch (Exception e) {
-			log.debug("Error generating new token",e);
+			log.error("Error generating new token",e);
 		}
 
 

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/RegisterNewSeedSql.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/RegisterNewSeedSql.java
@@ -131,7 +131,7 @@ public class RegisterNewSeedSql extends AbstractProfileAction {
 					.getSubcontext(UsernamePasswordContext.class);
 			return true;
 		} catch (Exception e) {
-			log.debug("Error with doPreExecute", e);
+			log.error("Error with doPreExecute", e);
 			return false;
 
 		}
@@ -188,7 +188,7 @@ public class RegisterNewSeedSql extends AbstractProfileAction {
         		new Object[] { username },
         		String.class);
 		} catch (Exception e) {
-			log.debug("existing seed not found");
+			log.error("existing seed not found");
 			existingSeed = null;
 		}
 
@@ -204,7 +204,7 @@ public class RegisterNewSeedSql extends AbstractProfileAction {
         		username, sharedSecret);
 			return true;
 		} catch (Exception e) {
-			log.debug("{} registerSeer error", getLogPrefix(), e);
+			log.error("{} registerSeer error", getLogPrefix(), e);
 			return false;
 		}
 

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/RegisterNewToken.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/RegisterNewToken.java
@@ -125,7 +125,7 @@ public class RegisterNewToken extends AbstractProfileAction {
 					.getSubcontext(UsernamePasswordContext.class);
 			return true;
 		} catch (Exception e) {
-			log.debug("Error with doPreExecute", e);
+			log.error("Error with doPreExecute", e);
 			return false;
 
 		}
@@ -139,7 +139,7 @@ public class RegisterNewToken extends AbstractProfileAction {
 		final TotpUtils totpUtils = new TotpUtils();
 
 		if (request == null) {
-			log.debug("{} Empty request", getLogPrefix());
+			log.error("{} Empty request", getLogPrefix());
 			ActionSupport.buildEvent(profileRequestContext, AuthnEventIds.NO_CREDENTIALS);
 			return;
 		}
@@ -188,7 +188,7 @@ public class RegisterNewToken extends AbstractProfileAction {
 			ldapTemplate.modifyAttributes(dn, new ModificationItem[] { item });
 			return true;
 		} catch (Exception e) {
-			log.debug("{} registerToken error", getLogPrefix(), e);
+			log.error("{} registerToken error", getLogPrefix(), e);
 			return false;
 		}
 

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpUtils.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpUtils.java
@@ -63,7 +63,7 @@ public class TotpUtils {
 			log.debug("{} User {} relative DN is: {}", username, (String) result.get(0));
 			dn = (String) result.get(0);
 		} else {
-			log.debug("{} User not found or not unique. DN size: {}", result.size());
+			log.warn("{} User not found or not unique. DN size: {}", result.size());
 			throw new RuntimeException("User not found or not unique");
 		}
 

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/seed/LdapSeedFetcher.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/seed/LdapSeedFetcher.java
@@ -60,7 +60,7 @@ public class LdapSeedFetcher implements SeedFetcher {
 			}
 		} catch (Exception e) {
 			tokenUserCtx.setState(AuthState.MISSING_SEED);
-			log.debug("Encountered problems with LDAP", e);
+			log.error("Encountered problems with LDAP", e);
 		}
 
 	}
@@ -83,7 +83,7 @@ public class LdapSeedFetcher implements SeedFetcher {
 			}
 			
 		} catch (Exception e) {
-			log.debug("Error with getAllTokenCodes", e);
+			log.error("Error with getAllTokenCodes", e);
 		}
 		
 		return tokenList;

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/seed/MongoSeedFetcher.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/seed/MongoSeedFetcher.java
@@ -43,7 +43,7 @@ public class MongoSeedFetcher implements SeedFetcher {
 				tokenUserCtx.setTokenSeed(user.getTokenSeed());
 			} catch (Exception e) {
 				log.debug("Aaaaand we got an error");
-				log.debug("Mongo Failed", e);
+				log.error("Mongo Failed", e);
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/seed/SQLSeedFetcher.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/seed/SQLSeedFetcher.java
@@ -73,7 +73,7 @@ public class SQLSeedFetcher implements SeedFetcher {
 			}
 		} catch (Exception e) {
 			tokenUserCtx.setState(AuthState.MISSING_SEED);
-			log.debug("Error accessing seed datasource", e);
+			log.error("Error accessing seed datasource", e);
 		}
 
 	}


### PR DESCRIPTION
## Changes proposed in this pull request:

Exceptions were being logged to the debug logger and therefore likely to get lost. This logs exceptions to the error logger.

## security considerations

Hopefully this prevents errors from being lost.
