### PR TITLE
update googleauth plugin from 0.5.0 to 1.5.0

### DIFF
--- a/totpauth-impl/build.gradle
+++ b/totpauth-impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation group: 'org.opensaml', name: 'opensaml-profile-api', version:'3.4.6'
   implementation group: 'org.opensaml', name: 'opensaml-soap-api', version:'3.4.6'
   implementation group: 'com.google.code.gson', name: 'gson', version:'2.3.1'
-  implementation group: 'com.warrenstrange', name: 'googleauth', version:'1.2.0'
+  implementation group: 'com.warrenstrange', name: 'googleauth', version:'1.5.0'
   implementation group: 'org.springframework.ldap', name: 'spring-ldap-core', version:'2.0.4.RELEASE'
   implementation group: 'org.springframework.data', name: 'spring-data-mongodb', version:'1.8.1.RELEASE'
   testImplementation group: 'junit', name: 'junit', version:'3.8.1'
@@ -32,7 +32,7 @@ dependencies {
   testImplementation group: 'net.shibboleth.idp', name: 'idp-authn-impl', version:'3.4.8'
 
   finaldeps project(':totpauth-api')
-  finaldeps group: 'com.warrenstrange', name: 'googleauth', version:'1.2.0'
+  finaldeps group: 'com.warrenstrange', name: 'googleauth', version:'1.5.0'
   finaldeps group: 'com.google.code.gson', name: 'gson', version:'2.3.1'
   finaldeps group: 'org.springframework.ldap', name: 'spring-ldap-core', version:'2.0.4.RELEASE'
   finaldeps group: 'org.springframework.data', name: 'spring-data-mongodb', version:'1.8.1.RELEASE'

--- a/totpauth-impl/build.gradle
+++ b/totpauth-impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation group: 'org.opensaml', name: 'opensaml-profile-api', version:'3.4.6'
   implementation group: 'org.opensaml', name: 'opensaml-soap-api', version:'3.4.6'
   implementation group: 'com.google.code.gson', name: 'gson', version:'2.3.1'
-  implementation group: 'com.warrenstrange', name: 'googleauth', version:'0.5.0'
+  implementation group: 'com.warrenstrange', name: 'googleauth', version:'1.2.0'
   implementation group: 'org.springframework.ldap', name: 'spring-ldap-core', version:'2.0.4.RELEASE'
   implementation group: 'org.springframework.data', name: 'spring-data-mongodb', version:'1.8.1.RELEASE'
   testImplementation group: 'junit', name: 'junit', version:'3.8.1'
@@ -32,7 +32,7 @@ dependencies {
   testImplementation group: 'net.shibboleth.idp', name: 'idp-authn-impl', version:'3.4.8'
 
   finaldeps project(':totpauth-api')
-  finaldeps group: 'com.warrenstrange', name: 'googleauth', version:'0.5.0'
+  finaldeps group: 'com.warrenstrange', name: 'googleauth', version:'1.2.0'
   finaldeps group: 'com.google.code.gson', name: 'gson', version:'2.3.1'
   finaldeps group: 'org.springframework.ldap', name: 'spring-ldap-core', version:'2.0.4.RELEASE'
   finaldeps group: 'org.springframework.data', name: 'spring-data-mongodb', version:'1.8.1.RELEASE'


### PR DESCRIPTION
## Changes proposed in this pull request:

- update googleauth plugin from 0.5.0 to 1.5.0 (latest) to fix broken QR code image generation
  - This was fixed in version 1.3.0: https://github.com/wstrange/GoogleAuth/issues/77

## security considerations

None, just updating the library that generates QR codes
