### PR TITLE
Update seed validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ totpauth-impl/build/
 # Java
 .class
 .jar
+.java-version

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ subprojects {
     maven { url "https://build.shibboleth.net/nexus/content/repositories/snapshots" }
     maven { url "https://build.shibboleth.net/nexus/content/repositories/thirdparty-snapshots" }
     maven { url "https://repo1.maven.org/maven2" }
+    maven { url "https://build.shibboleth.net/maven/thirdparty/"}
   }
 
 

--- a/totpauth-impl/build.gradle
+++ b/totpauth-impl/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   implementation group: 'com.warrenstrange', name: 'googleauth', version:'1.5.0'
   implementation group: 'org.springframework.ldap', name: 'spring-ldap-core', version:'2.0.4.RELEASE'
   implementation group: 'org.springframework.data', name: 'spring-data-mongodb', version:'1.8.1.RELEASE'
+  testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
   testImplementation group: 'junit', name: 'junit', version:'3.8.1'
   testImplementation group: 'net.shibboleth.idp', name: 'idp-attribute-resolver-impl', version:'3.4.8'
   testImplementation group: 'net.shibboleth.idp', name: 'idp-attribute-resolver-spring', version:'3.4.8'
@@ -30,6 +31,7 @@ dependencies {
   testImplementation group: 'net.shibboleth.idp', name: 'idp-authn-api', version:'3.4.8'
   testImplementation group: 'net.shibboleth.idp', name: 'idp-authn-impl', version:'3.4.8'
   testImplementation group: 'net.shibboleth.idp', name: 'idp-authn-impl', version:'3.4.8'
+
 
   finaldeps project(':totpauth-api')
   finaldeps group: 'com.warrenstrange', name: 'googleauth', version:'1.5.0'

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpSeedValidator.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpSeedValidator.java
@@ -1,0 +1,32 @@
+package net.kvak.shibboleth.totpauth.authn.impl;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.warrenstrange.googleauth.GoogleAuthenticator;
+
+import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
+
+public class TotpSeedValidator {
+	/** Class logger. */
+	@Nonnull
+	@NotEmpty
+	private final Logger log = LoggerFactory.getLogger(RegisterNewToken.class);
+
+  public boolean validateToken(GoogleAuthenticator gAuth, String seed, int token) {
+		log.debug("Entering validatetoken");
+
+		int[] allowedSeedLengths = {16, 32};
+
+		if (ArrayUtils.contains(allowedSeedLengths, seed.length()) && StringUtils.isAlphanumeric(seed)) {
+			log.debug("Authorize {} - {} ", seed, token);
+			return gAuth.authorize(seed, token);
+		}
+		log.debug("Token code validation failed. Seed value does not match expected lengths: {}", allowedSeedLengths.toString());
+		return false;
+	}
+}

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpTokenValidator.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpTokenValidator.java
@@ -26,16 +26,18 @@ import net.shibboleth.utilities.java.support.primitive.StringSupport;
 
 /**
  * Validates users TOTP token code against injected authenticator
- * 
+ *
  * An action that checks for a {@link TokenCodeContext} and directly produces an
  * {@link net.shibboleth.idp.authn.AuthenticationResult} based on submitted
  * tokencode and username
- * 
+ *
  * @author korteke
  *
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class TotpTokenValidator extends AbstractValidationAction implements TokenValidator {
+
+	private TotpSeedValidator totpSeedValidator;
 
 	/** Class logger. */
 	@Nonnull
@@ -72,7 +74,7 @@ public class TotpTokenValidator extends AbstractValidationAction implements Toke
 	/** Constructor **/
 	public TotpTokenValidator() {
 		super();
-
+		this.totpSeedValidator = new TotpSeedValidator();
 	}
 
 	@Override
@@ -132,14 +134,7 @@ public class TotpTokenValidator extends AbstractValidationAction implements Toke
 
 	@Override
 	public boolean validateToken(String seed, int token) {
-		log.debug("{} Entering validatetoken", getLogPrefix());
-
-		if (seed.length() == 16) {
-			log.debug("{} authorize {} - {} ", getLogPrefix(), seed, token);
-			return gAuth.authorize(seed, token);
-		}
-		log.debug("{} Token code validation failed. Seed is not 16 char long", getLogPrefix());
-		return false;
+		return this.totpSeedValidator.validateToken(gAuth, seed, token);
 	}
 
 	@Override

--- a/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpUtils.java
+++ b/totpauth-impl/src/main/java/net/kvak/shibboleth/totpauth/authn/impl/TotpUtils.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ldap.core.DirContextOperations;
@@ -19,6 +18,8 @@ import net.shibboleth.utilities.java.support.annotation.constraint.NotEmpty;
 
 @SuppressWarnings("deprecation")
 public class TotpUtils {
+
+	private TotpSeedValidator totpSeedValidator;
 	
 	/** Class logger. */
 	@Nonnull
@@ -33,17 +34,11 @@ public class TotpUtils {
 
 	public TotpUtils() {
 		this.gAuth = new GoogleAuthenticator();
+		this.totpSeedValidator = new TotpSeedValidator();
 	}
-	
-	public boolean validateToken(String seed, int token) {
-		log.debug("Entering validatetoken");
 
-		if (seed.length() == 16 && StringUtils.isAlphanumeric(seed)) {
-			log.debug("Authorize {} - {} ", seed, token);
-			return gAuth.authorize(seed, token);
-		}
-		log.debug("Token code validation failed. Seed value is invalid");
-		return false;
+	public boolean validateToken(String seed, int token) {
+		return this.totpSeedValidator.validateToken(gAuth, seed, token);
 	}
 	
 	@SuppressWarnings({ "unchecked", "rawtypes", "unused" })

--- a/totpauth-impl/src/test/java/net/kvak/shibboleth/totpauth/authn/impl/TotpSeedValidatorTest.java
+++ b/totpauth-impl/src/test/java/net/kvak/shibboleth/totpauth/authn/impl/TotpSeedValidatorTest.java
@@ -1,0 +1,65 @@
+package net.kvak.shibboleth.totpauth.authn.impl;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.apache.commons.lang.RandomStringUtils;
+import static org.mockito.Mockito.*;
+
+import com.warrenstrange.googleauth.GoogleAuthenticator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TotpSeedValidatorTest {
+
+    private GoogleAuthenticator gAuthMock;
+    private TotpSeedValidator totpSeedValidator;
+
+    @Before
+    public void setUp() throws Exception {
+        totpSeedValidator = new TotpSeedValidator();
+        gAuthMock = mock(GoogleAuthenticator.class);
+        when(gAuthMock.authorize(anyString(), anyInt())).thenReturn(true);
+    }
+
+
+    @Test
+    public void Test16CharacterSeed() {
+        int length = 16;
+        boolean useLetters = true;
+        boolean useNumbers = false;
+        String seed = RandomStringUtils.random(length, useLetters, useNumbers);
+
+        assertTrue(
+            "16 character seed should be accepted",
+            totpSeedValidator.validateToken(this.gAuthMock, seed, 123456)
+        );
+    }
+
+    @Test
+    public void Test32CharacterSeed() {
+        int length = 32;
+        boolean useLetters = true;
+        boolean useNumbers = false;
+        String seed = RandomStringUtils.random(length, useLetters, useNumbers);
+
+        assertTrue(
+            "32 character seed should be accepted",
+            totpSeedValidator.validateToken(this.gAuthMock, seed, 123456)
+        );
+    }
+
+    @Test
+    public void TestBadCharacterSeed() {
+        int length = 8;
+        boolean useLetters = true;
+        boolean useNumbers = false;
+        String seed = RandomStringUtils.random(length, useLetters, useNumbers);
+
+        assertFalse(
+            "9 character seed should not be accepted",
+            totpSeedValidator.validateToken(this.gAuthMock, seed, 123456)
+        );
+    }
+}

--- a/totpauth-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/totpauth-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/shibboleth-boshrelease/issues/146

https://github.com/cloud-gov/Shibboleth-IdP3-TOTP-Auth/pull/32 broke existing TOTP with seed lengths of 16 characters. This PR:

- re-adds support for seed lengths of 16 characters
- refactors code for validating token seeds into TotpSeedValidator class
- adds mockito package for testing
- adds a basic unit test to verify that allowed seed lengths are handled correctly

## security considerations

This will allow TOTP seeds with lengths of both 16 and 32 characters to be handled correctly, which has no security impact but does ensure that users with existing TOTP seeds that are 16 characters can still log in
