### PR TITLE
Allstar - Add binary artifacts ignore paths 

### DIFF
--- a/.allstar/binary_artifacts.yaml
+++ b/.allstar/binary_artifacts.yaml
@@ -1,0 +1,4 @@
+# Ignore reason: These files are required for the Gradle wrapper, which is used when building the project:
+# https://github.com/cloud-gov/shibboleth-boshrelease/blob/main/packages/idp/packaging#L31
+ignorePaths:
+- gradle/wrapper/gradle-wrapper.jar

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @cloud-gov/platform-ops
+


### PR DESCRIPTION
## Changes proposed in this pull request:

- add configuration to ignore Gradle wrapper files for Allstar binary artifacts policy
- add CODEOWNERS file

## security considerations

We are excluding the configured files from Allstar's binary artifacts check since they are trusted Gradle files
