### PR TITLE
chore: bump java and logback-classic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ allprojects  {
 
 subprojects {
   apply plugin: 'java'
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
+  sourceCompatibility = '11'
+  targetCompatibility = '11'
   tasks.withType(JavaCompile) {
   	options.encoding = 'UTF-8'
   }
@@ -32,13 +32,13 @@ subprojects {
     implementation group: 'org.opensaml', name: 'opensaml-messaging-api', version:'3.4.6'
     implementation group: 'org.springframework', name: 'spring-context-support', version:'4.2.3.RELEASE'
     implementation group: 'org.springframework', name: 'spring-jdbc', version: '4.2.3.RELEASE'
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.3.14'
     implementation 'javax.servlet:javax.servlet-api:3.0.1'
     testImplementation group: 'org.springframework', name: 'spring-test', version:'4.2.3.RELEASE'
     testImplementation group: 'net.shibboleth.utilities', name: 'java-support', version:'7.2.0'
     testImplementation group: 'org.testng', name: 'testng', version:'6.9.9'
     testImplementation group: 'xmlunit', name: 'xmlunit', version:'1.6'
-    
+
 }
 
   test.useTestNG()


### PR DESCRIPTION
## Changes proposed in this pull request:
- bump java (so gradle tests against what we run against) and logback-classic (to fix launch failures)

## security considerations
None